### PR TITLE
[gem-template] Improve Simplecov filter

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ require 'simplecov'
 
 SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
 SimpleCov.minimum_coverage(100)
-SimpleCov.start { add_filter 'spec' }
+SimpleCov.start { add_filter '/spec' }
 
 require 'bundler/setup'
 require 'gem_template'


### PR DESCRIPTION
If the gem's name contains the string `spec`, SimpleCov will filter out its source code.